### PR TITLE
Enable deleting connections

### DIFF
--- a/includes/chart.js
+++ b/includes/chart.js
@@ -591,7 +591,6 @@ function drawConnection(event) {
     line.setAttribute("start-shape-id_", startShapeId);
     line.setAttribute("end-shape-id_", destinationShapeId);
 
-    console.log(line.getAttribute('id'));
     // Append the line to the edges group or svg container
     connectionGroup.appendChild(line);
 
@@ -605,14 +604,12 @@ function deleteConnection(event) {
     let destinationShapeId = destinationNode.id;
 
     if (destinationNode.tagName !== 'ellipse' && destinationNode.tagName !== 'polygon' && destinationNode.tagName !== 'rect') {
-        console.log(destinationNode);
         return;
     }
 
     let startRowIdNum = parseInt(startShapeId, 10);
     let destinationRowIdNum = parseInt(destinationShapeId, 10);
 
-    console.log(`connector_${startRowIdNum}-${destinationRowIdNum}`);
     line = document.getElementById(`connector_${startRowIdNum}-${destinationRowIdNum}`);
     // If no such line, try finding a line the other way around
     if (!line) {


### PR DESCRIPTION
Fixes #57

Uses the same interaction as creating the statements in the first place: right click statement, click 'delete connection', click other statement to delete connection with it.

Changes summary:

- add deleteConnection function
- separate drawConnection as function
- use statement.id instead of rowindex