### PR TITLE
Store and load inter-statement connections using session

### DIFF
--- a/includes/chart.js
+++ b/includes/chart.js
@@ -570,7 +570,7 @@ function getParentTransform(node) {
 }
 
 
-// Add event listener for double-click to select the destination node and draw the line
+// Add event listener for click to select the destination node and draw the line
 document.addEventListener('click', function(event) {
     if (INA.isDrawingConnection) {
         drawConnection(event);
@@ -588,7 +588,20 @@ function drawConnection(event) {
     }
 
     console.log('Selected destination node:', destinationShapeId);
-    let startNode = document.getElementById(INA.startShapeId);
+    let startShapeId = INA.startShapeId;
+    let connectionColor = INA.connectionColor;
+
+    createConnection(startShapeId, destinationShapeId, connectionColor);
+
+    // Reset the drawing state
+    INA.isDrawingConnection = false;
+    INA.startShapeId = null;
+    INA.connectionColor = null;
+}
+
+function createConnection(startShapeId, destinationShapeId, connectionColor) {
+    let startNode = document.getElementById(startShapeId);
+    let destinationNode = document.getElementById(destinationShapeId);
     let [startX, startY] = determineCenter(startNode);
     let startTransform = getParentTransform(startNode);
     let [endX, endY] = determineCenter(destinationNode);
@@ -596,7 +609,7 @@ function drawConnection(event) {
 
     // Create a line element and append it to the SVG
     let line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    line.setAttribute("stroke", INA.connectionColor);
+    line.setAttribute("stroke", connectionColor);
     line.setAttribute("stroke-width", "5");
     line.setAttribute("x1", startX + startTransform.translateX);
     line.setAttribute("y1", startY + startTransform.translateY);
@@ -604,7 +617,7 @@ function drawConnection(event) {
     line.setAttribute("y2", endY + destinationTransform.translateY);
 
     // Convert startShapeId and destinationShapeId to numbers
-    let startRowIdNum = parseInt(INA.startShapeId, 10);
+    let startRowIdNum = parseInt(startShapeId, 10);
     let destinationRowIdNum = parseInt(destinationShapeId, 10);
 
     // Check if the conversion was successful
@@ -616,16 +629,12 @@ function drawConnection(event) {
     line.setAttribute("data-start-row-id", startRowIdNum);
     line.setAttribute("data-end-row-id", destinationRowIdNum);
     line.setAttribute("id", "connector_" + startRowIdNum + "-" + destinationRowIdNum);
-    line.setAttribute("start-shape-id_", INA.startShapeId);
+    line.setAttribute("start-shape-id_", startShapeId);
     line.setAttribute("end-shape-id_", destinationShapeId);
 
     // Append the line to the edges group or svg container
+    connectionGroup = document.getElementById("connectionGroup");
     connectionGroup.appendChild(line);
-
-    // Reset the drawing state
-    INA.isDrawingConnection = false;
-    INA.startShapeId = null;
-    INA.connectionColor = null;
 }
 
 function deleteConnection(event) {

--- a/includes/chart.js
+++ b/includes/chart.js
@@ -643,6 +643,9 @@ function createConnection(startShapeId, destinationShapeId, connectionColor) {
 
 function renderOnLoad(statements, connections) {
     addNodesAndLinks(statements);
+    // For some reason, using connections.forEach(...) here instead results in
+    // document.getElementById(startShapeId) returning null for some reason,
+    // which is why this is an explicit, regular for-loop instead.
     for (let i=0; i<connections.length; i++) {
         createConnection(...connections[i]);
     }

--- a/includes/chart.js
+++ b/includes/chart.js
@@ -641,6 +641,13 @@ function createConnection(startShapeId, destinationShapeId, connectionColor) {
     connectionGroup.appendChild(line);
 }
 
+function renderOnLoad(statements, connections) {
+    addNodesAndLinks(statements);
+    for (let i=0; i<connections.length; i++) {
+        createConnection(...connections[i]);
+    }
+}
+
 function deleteConnection(event) {
     let destinationNode = event.target;
     let destinationShapeId = destinationNode.id;
@@ -661,9 +668,7 @@ function deleteConnection(event) {
         }
 
         // reverse line was found, so swap INA.startShapeId and destinationShapeId
-        let tmp = INA.startShapeId;
-        INA.startShapeId = destinationShapeId;
-        destinationShapeId = tmp;
+        [INA.startShapeId, destinationShapeId] = [destinationShapeId, INA.startShapeId]
     }
 
     // Remove line from session tracking

--- a/includes/store_session_data.php
+++ b/includes/store_session_data.php
@@ -11,6 +11,7 @@ if(isset($_POST['Columns'])) {
     // Store the received table data in session variable
     $_SESSION['Columns'] = $_POST['Columns'];
     $_SESSION['Statements'] = $_POST['Statements'];
+    $_SESSION['Connections'] = $_POST['Connections'];
 } else {
     echo "No data received";
 }

--- a/includes/uploader.js
+++ b/includes/uploader.js
@@ -40,6 +40,8 @@ const expectedColumnNames = [
 // Initialise a global namespace variable 'INA' to store global variables during the session
 window.INA = {};
 INA.statements;
+INA.columnNames;
+INA.connections = [];
 
 // Check table and initialize session variable to handle file upload properly
 function checkPreviousSessions() {
@@ -235,7 +237,8 @@ function storeDatainSession() {
         method: 'POST',
         data: {
             Columns: INA.columnNames,
-            Statements: INA.statements
+            Statements: INA.statements,
+            Connections: INA.connections,
         },
         success: function (response) {
             console.log('Session data stored successfully');

--- a/index.php
+++ b/index.php
@@ -115,11 +115,11 @@ include_once 'includes/header.php';
                                             echo "</tbody>";
                                             echo "</table>";
 
-                                            // Render also chart
-
+                                            // Render chart: statements and connections
                                             echo "<script>document.getElementById('quoteBlock').hidden = true;</script>";
                                             $statements = json_encode($_SESSION['Statements']);
-                                            echo "<script>addNodesAndLinks($statements)</script>";
+                                            $connections = json_encode($_SESSION['Connections']);
+                                            echo "<script>renderOnLoad($statements, $connections)</script>";
 
 
                                         }


### PR DESCRIPTION
Fixes #62

Stores an inter-statement connection as `[startShapeId, destinationShapeId, connectionColor]` triplets in the `INA.connections` array. Upon addition or deletion, session storage is refreshed. When refreshing the page, calls a new `renderOnLoad` function that wraps both the original `addNodesAndLinks` and the new `createConnection` calls.

Note that for the latter, `connections.forEach(...)` would result in `document.getElementById(startShapeId)` returning null for some reason, which is why it's an explicit, regular `for`-loop instead.