### PR TITLE
Refactor file upload/page refresh logic

### DIFF
--- a/includes/chart.js
+++ b/includes/chart.js
@@ -658,12 +658,7 @@ function renderOnLoad(statements, connections, projectName) {
     INA.connections = connections;
     INA.projectName = projectName;
 
-    // Reconstruct 'columnNames' from a statement object
-    let columnNames = Object.keys(statements[0]);
-    removeFromArray('_translate', columnNames);
-    INA.columnNames = columnNames;
-
-    populateTable(columnNames, INA.statements);
+    populateTable(INA.statements);
 
     addNodesAndLinks(statements);
     // For some reason, using connections.forEach(...) here instead results in

--- a/includes/chart.js
+++ b/includes/chart.js
@@ -654,13 +654,14 @@ function createConnection(startShapeId, destinationShapeId, connectionColor) {
 function renderOnLoad() {
     populateTable(INA.statements);
     addNodesAndLinks(INA.statements);
-
     // For some reason, using connections.forEach(...) here instead results in
     // document.getElementById(startShapeId) returning null for some reason,
     // which is why this is an explicit, regular for-loop instead.
     for (let i=0; i<INA.connections.length; i++) {
         createConnection(...INA.connections[i]);
     }
+
+    storeDatainSession();
 }
 
 function deleteConnection(event) {

--- a/includes/chart.js
+++ b/includes/chart.js
@@ -663,6 +663,8 @@ function renderOnLoad(statements, connections, projectName) {
     removeFromArray('_translate', columnNames);
     INA.columnNames = columnNames;
 
+    populateTable(columnNames, INA.statements);
+
     addNodesAndLinks(statements);
     // For some reason, using connections.forEach(...) here instead results in
     // document.getElementById(startShapeId) returning null for some reason,

--- a/includes/chart.js
+++ b/includes/chart.js
@@ -651,21 +651,15 @@ function createConnection(startShapeId, destinationShapeId, connectionColor) {
     connectionGroup.appendChild(line);
 }
 
-function renderOnLoad(statements, connections, projectName) {
-
-    // Repopulate the global INA namespace with loaded information
-    INA.statements = statements;
-    INA.connections = connections;
-    INA.projectName = projectName;
-
+function renderOnLoad() {
     populateTable(INA.statements);
+    addNodesAndLinks(INA.statements);
 
-    addNodesAndLinks(statements);
     // For some reason, using connections.forEach(...) here instead results in
     // document.getElementById(startShapeId) returning null for some reason,
     // which is why this is an explicit, regular for-loop instead.
-    for (let i=0; i<connections.length; i++) {
-        createConnection(...connections[i]);
+    for (let i=0; i<INA.connections.length; i++) {
+        createConnection(...INA.connections[i]);
     }
 }
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -163,7 +163,7 @@ if (isset($_POST['destroy_session'])) {
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick = 'confirmUpload()'>Confirm upload</button>
+                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick = 'renderOnLoad()'>Confirm upload</button>
                 </div>
                 </div>
             </div>

--- a/includes/store_session_data.php
+++ b/includes/store_session_data.php
@@ -7,9 +7,8 @@
 session_start();
 
 // Check if table data is received via POST
-if(isset($_POST['Columns'])) {
+if(isset($_POST['Statements'])) {
     // Store the received table data in session variable
-    $_SESSION['Columns'] = $_POST['Columns'];
     $_SESSION['Statements'] = $_POST['Statements'];
     $_SESSION['Connections'] = $_POST['Connections'];
     $_SESSION['ProjectName'] = $_POST['ProjectName'];

--- a/includes/uploader.js
+++ b/includes/uploader.js
@@ -186,9 +186,9 @@ function checkFileContent() {
 
         // Check if the file content has comma as a separator
         if (content.includes(',')) {
-            let lines = content.split('\n');
-            let columnNames = lines[0].replace('\r', '').split(',');
-            columnNames = columnNames.map(name => toTitleCase(name));
+            const lines = content.split('\n');
+            const columnNamesRaw = lines[0].replace('\r', '').split(',');
+            let columnNames = columnNamesRaw.map(name => toTitleCase(name));
             let rowValues = lines.slice(1).map(row => row.split(','));
 
             // Add an ID column in front if not already present
@@ -282,10 +282,10 @@ function populateTable(statements) {
     $('#tableData').empty();
 
     // Extract columnNames from statements objects
-    let columnNames = Object.keys(statements[0]);
+    const columnNames = Object.keys(statements[0]);
     removeFromArray('_translate', columnNames);
 
-    let columnsArray = columnNames.map(columnName => {
+    const columnsArray = columnNames.map(columnName => {
         return {title: columnName}
     })
 

--- a/includes/uploader.js
+++ b/includes/uploader.js
@@ -124,7 +124,6 @@ function handleFileUpload(files) {
             checkFileContent();
             break;
         case 'json':
-            console.log('here follows json parsing');
             loadFromJsonUpload();
             break;
         default:
@@ -237,15 +236,6 @@ function checkColumnNames(columnNames) {
     }
 }
 
-// FIXME: this function currently serves as entry point from the upload dialog,
-//        but is only doing superfluous/double work. Combine with `renderOnLoad`
-//
-// Function to confirm upload and fill rows in an existing table
-function confirmUpload() {
-    renderOnLoad(INA.statements, INA.connections, INA.projectName);
-}
-
-
 function storeDatainSession() {
 
     // Send the generated table data to PHP script via AJAX
@@ -315,4 +305,10 @@ function populateTable(statements) {
 
     // Store table data in session
     storeDatainSession();
+}
+
+function loadProjectIntoGlobalScope(projectName, statements, connections) {
+    INA.projectName = projectName;
+    INA.statements = statements;
+    INA.connections = connections;
 }

--- a/includes/uploader.js
+++ b/includes/uploader.js
@@ -247,8 +247,6 @@ function confirmUpload() {
 
     let columnNames = Object.keys(INA.statements[0]);
     removeFromArray('_translate', columnNames);
-
-    populateTable(columnNames, INA.statements);
     renderOnLoad(INA.statements, INA.connections, INA.projectName);
 }
 

--- a/includes/uploader.js
+++ b/includes/uploader.js
@@ -307,7 +307,7 @@ function populateTable(statements) {
     storeDatainSession();
 }
 
-function loadProjectIntoGlobalScope(projectName, statements, connections) {
+function loadProjectIntoGlobalScope(statements, connections, projectName) {
     INA.projectName = projectName;
     INA.statements = statements;
     INA.connections = connections;

--- a/includes/uploader.js
+++ b/includes/uploader.js
@@ -302,9 +302,6 @@ function populateTable(statements) {
 
     // Set the table rows
     dataTable.rows.add(uploadedRowValues).draw();
-
-    // Store table data in session
-    storeDatainSession();
 }
 
 function loadProjectIntoGlobalScope(statements, connections, projectName) {

--- a/index.php
+++ b/index.php
@@ -90,7 +90,10 @@ include_once 'includes/header.php';
                                         $statements = json_encode($_SESSION['Statements']);
                                         $connections = json_encode($_SESSION['Connections']);
                                         $projectName = json_encode($_SESSION['ProjectName']);
-                                        echo "<script>renderOnLoad($statements, $connections, $projectName)</script>";
+                                        echo "<script>
+                                            loadProjectIntoGlobalScope($statements, $connections, $projectName);
+                                            renderOnLoad();
+                                        </script>";
 
                                     }
                                     ?>

--- a/index.php
+++ b/index.php
@@ -74,59 +74,24 @@ include_once 'includes/header.php';
                             </div>
                             <div class="card-body">
                                 <div style="overflow-x: auto;">
+                                <table id='tableData' class='display' style='width:100%'></table>
                                     <?php
                                     // Check if the session variable is set and not empty
                                     if (isset($_SESSION['Columns']) && !empty($_SESSION['Columns'])) {
-                                        // Check if $_SESSION['Columns'] is an array
-                                        if (is_array($_SESSION['Columns'])) {
-                                            // If it's an array, you need to loop through it to display each element
-                                            echo "<table id='tableData' class='display' style='min-width: 100%'>";
 
-                                            // Must re-initilize the table to retrieve jQuery features from https://datatables.net/
-                                            echo "<script> $(document).ready(function() {
-                                                $('#tableData').DataTable();
-                                                });
-                                            </script>";
+                                        // Must re-initilize the table to retrieve jQuery features from https://datatables.net/
+                                        echo "<script> $(document).ready(function() {
+                                            $('#tableData').DataTable();
+                                            });
+                                        </script>";
 
+                                        // Populate table and render chart
+                                        echo "<script>document.getElementById('quoteBlock').hidden = true;</script>";
+                                        $statements = json_encode($_SESSION['Statements']);
+                                        $connections = json_encode($_SESSION['Connections']);
+                                        $projectName = json_encode($_SESSION['ProjectName']);
+                                        echo "<script>renderOnLoad($statements, $connections, $projectName)</script>";
 
-                                            echo "<thead>";
-                                            echo "<tr>";
-                                            foreach ($_SESSION['Columns'] as $column) {
-                                                if (!empty($column)) {
-                                                    echo "<th>$column</th>";
-                                                }
-                                            }
-                                            echo "</tr>";
-                                            echo "</thead>";
-
-                                            // Build Table body
-
-                                            echo "<tbody>";
-
-                                            // Loop through each statement to populate the rows of the table body
-                                            foreach ($_SESSION['Statements'] as $statement) {
-                                                echo "<tr>";
-                                                // Loop through each column value in the statement
-                                                foreach ($_SESSION['Columns'] as $column) {
-                                                    echo "<td>$statement[$column]</td>";
-                                                }
-                                                echo "</tr>";
-                                            }
-                                            echo "</tbody>";
-                                            echo "</table>";
-
-                                            // Render chart: statements and connections
-                                            echo "<script>document.getElementById('quoteBlock').hidden = true;</script>";
-                                            $statements = json_encode($_SESSION['Statements']);
-                                            $connections = json_encode($_SESSION['Connections']);
-                                            $projectName = json_encode($_SESSION['ProjectName']);
-                                            echo "<script>renderOnLoad($statements, $connections, $projectName)</script>";
-
-
-                                        }
-                                    } else {
-                                        echo "<table id='tableData' class='display' style='width:100%'></table>";
-                                        // echo "<p>No table data available.</p>";
                                     }
                                     ?>
                                 </div>

--- a/index.php
+++ b/index.php
@@ -77,7 +77,7 @@ include_once 'includes/header.php';
                                 <table id='tableData' class='display' style='width:100%'></table>
                                     <?php
                                     // Check if the session variable is set and not empty
-                                    if (isset($_SESSION['Columns']) && !empty($_SESSION['Columns'])) {
+                                    if (isset($_SESSION['Statements']) && !empty($_SESSION['Statements'])) {
 
                                         // Must re-initilize the table to retrieve jQuery features from https://datatables.net/
                                         echo "<script> $(document).ready(function() {


### PR DESCRIPTION
Combined PR for three issues that are all part of refactoring and streamlining the code flow when either uploading a file or refreshing the page.

- Fixes #95
  Deduplicate functionality: only use `populateTable` function in javascript, remove PHP/html datatable creation
- Fixes #102
  Remove 'columnNames' from global state and session storage: can be extracted from `statement` objects
- Fixes #99 
  combine `confirmUpload` and `renderOnLoad` functions; make `renderOnLoad` get all values from the global `INA` namespace, and add a dedicated function to set values in the `INA` namespace when needed (such as on a page refresh)