### PR TITLE
Add de-duplicate button + move canvas actions to menu

### DIFF
--- a/spa/INA-tool/src/components/Canvas.tsx
+++ b/spa/INA-tool/src/components/Canvas.tsx
@@ -4,7 +4,6 @@ import {
   ReactFlow,
   Controls,
   MiniMap,
-  Panel,
   ReactFlowProvider,
   Connection,
 } from "@xyflow/react";
@@ -14,11 +13,7 @@ import { edgeTypes } from "./edges";
 import { buildEdge } from "@/lib/edge";
 import { INAEdge } from "@/lib/edge";
 import { useTheme } from "./theme-provider";
-import { ScreenshotButton } from "./ScreenshotButton";
-import { LayoutButton } from "./LayoutButton";
 import { ConnectionLine } from "./ConnectionLine";
-import { CanvasLegendButton } from "./CanvasLegendButton";
-import { CompactSwitch } from "./CompactSwitch";
 import { useState } from "react";
 import {
   hasAmbiguousSource,


### PR DESCRIPTION
Only shows first node with same text and type. The edges of duplicated nodes are re-assigned to shown node.

With duplicated label:
![localhost_5173__project=Example](https://github.com/user-attachments/assets/4c229e23-b935-4ece-8126-421b831c6fee)

After de-duplication:
![localhost_5173__project=Example (1)](https://github.com/user-attachments/assets/a79a4943-a6bb-4bb7-b1e4-87aff0e27f9c)


Refs #81