### PR TITLE
Change conflict edge color from red to amber

### DIFF
--- a/src/components/NetworkLegend.tsx
+++ b/src/components/NetworkLegend.tsx
@@ -80,7 +80,7 @@ function BaseLegend({
           <EdgeLegend className={textColor.sanction} text="Sanction driven" />
           <li className="flex items-center gap-2">
             <div className="w-8">
-              <DashedIcon className="text-red-500" />
+              <DashedIcon className="text-amber-500" />
             </div>
             <div>Conflict</div>
           </li>

--- a/src/lib/edge.ts
+++ b/src/lib/edge.ts
@@ -84,7 +84,7 @@ export const drivenColors = {
   actor: "#a855f7",
   outcome: "#22c55e",
   sanction: "#ef4444",
-  conflict: "#ef4444",
+  conflict: "#fd9a00",
 } as const;
 
 export function isDrivenConnection(


### PR DESCRIPTION
Fixes #149 

The [tailwind amber-500](https://tailwindcss.com/docs/colors) was converted to rgb using https://oklch.com/