### PR TITLE
Smart edge routing 150

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/StartBootstrap/startbootstrap-sb-admin/master/LICENSE)
 [![Deploy app to GH Pages](https://github.com/ESI-FAR/INA-tool/actions/workflows/deploy.yml/badge.svg)](https://github.com/ESI-FAR/INA-tool/actions/workflows/deploy.yml)
 [![Build](https://github.com/ESI-FAR/INA-tool/actions/workflows/build.yml/badge.svg)](https://github.com/ESI-FAR/INA-tool/actions/workflows/build.yml)
+[![Research Software Directory Badge](https://img.shields.io/badge/rsd-ina_tool-00a3e3.svg)](https://research-software-directory.org/software/ina-tool)
 
 INA Tool is an open-source digital tool developed by the eScience Center aimed at supporting the regulatory framework design process by facilitating the study, analysis, and decision-making through data visualization and interaction.
 

--- a/src/components/ClearButton.tsx
+++ b/src/components/ClearButton.tsx
@@ -1,6 +1,7 @@
 import { TrashIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import { store } from "@/stores/global";
+import { useEffect } from "react";
 
 function removeAllData() {
   const projectName = store.getState().projectName;
@@ -16,6 +17,20 @@ function removeAllData() {
 
 export function ClearButton() {
   // TODO only show|enable clear button if there are nodes or edges
+
+  // Add keyboard shortcut for clearing data
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "r") {
+        e.preventDefault();
+        removeAllData();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <Button
       title="Remove all data"

--- a/src/components/ComponentNetworkMenu.tsx
+++ b/src/components/ComponentNetworkMenu.tsx
@@ -13,8 +13,9 @@ import {
 import { download } from "@/lib/io";
 import { store as networkStore } from "@/stores/component-network";
 import { store } from "@/stores/global";
-import { ComponentLayoutButton } from "./LayoutButton";
+import { ComponentLayoutButton, useComponentLayout } from "./LayoutButton";
 import { ScreenshotButton } from "./ScreenshotButton";
+import { useEffect } from "react";
 
 function exportAsGraphml() {
   const projectName = store.getState().projectName;
@@ -35,6 +36,18 @@ function exportAsGexf() {
 }
 
 export function ComponentNetworkMenu() {
+  const autoLayout = useComponentLayout();
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "l") {
+        e.preventDefault();
+        autoLayout();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [autoLayout]);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/src/components/LayoutButton.tsx
+++ b/src/components/LayoutButton.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useReactFlow } from "@xyflow/react";
-import ELK from "elkjs/lib/elk-api";
+import ELK, { ElkEdge, ElkExtendedEdge } from "elkjs/lib/elk-api";
 import ELKworker from "elkjs/lib/elk-worker.js?worker";
 import { LayoutTemplateIcon } from "lucide-react";
 import { isComponentNode, isStatementNode } from "@/lib/node";
@@ -18,8 +18,10 @@ type Port = {
   id: string;
   layoutOptions?: {
     "elk.port.side"?: "WEST" | "EAST" | "NORTH" | "SOUTH";
-    "elk.port.index"?: number;
+    "elk.port.index"?: string;
   };
+  width?: number;
+  height?: number;
 };
 
 function computePorts(node: INANode) {
@@ -34,96 +36,115 @@ function computePorts(node: INANode) {
       return ports.concat([
         {
           id: node.parentId + "-Activation Condition-2-Attribute",
-          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": 2 },
+          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": "2" },
+          width: 5, height: 5,
         },
         {
           id: node.id + "-outcome",
-          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 0 },
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": "0" },
+          width: 5, height: 5,
         },
         {
           id: node.id + "-sanction",
-          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 1 },
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": "1" },
+          width: 5, height: 5,
         },
       ]);
     case "Attribute":
       return ports.concat([
         {
           id: node.parentId + "-Attribute-2-Activation Condition",
-          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": 0 },
+          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": "0" },
+          width: 5, height: 5,
         },
         {
           id: node.parentId + "-Attribute-2-Aim",
-          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": 1 },
+          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": "1" },
+          width: 5, height: 5,
         },
         {
           id: node.id + "-actor",
-          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 2 },
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": "2" },
+          width: 5, height: 5,
         },
       ]);
     case "Aim":
       return ports.concat([
         {
           id: node.parentId + "-Aim-2-Attribute",
-          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": 2 },
+          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": "2" },
+          width: 5, height: 5,
         },
         {
           id: node.parentId + "-Aim-2-Direct Object",
-          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": 3 },
+          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": "3" },
+          width: 5, height: 5,
         },
         {
           id: node.parentId + "-Aim-2-Execution Constraint",
-          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 0 },
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "0" },
+          width: 5, height: 5,
         },
         {
           id: node.id + "-sanction",
-          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "1" },
+          width: 5, height: 5,
         },
       ]);
     case "Direct Object":
       return ports.concat([
         {
           id: node.parentId + "-Direct Object-2-Aim",
-          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": 2 },
+          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": "2" },
+          width: 5, height: 5,
         },
         {
           id: node.parentId + "-Direct Object-2-Indirect Object",
-          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 0 },
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "0" },
+          width: 5, height: 5,
         },
         node.data.animation === "animate"
           ? {
-              id: node.id + "-actor",
-              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
-            }
+          id: node.id + "-actor",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "1" },
+          width: 5, height: 5,
+        }
           : {
-              id: node.id + "-outcome",
-              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
-            },
+          id: node.id + "-outcome",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "1" },
+          width: 5, height: 5,
+        },
       ]);
     case "Indirect Object":
       return ports.concat([
         {
           id: node.parentId + "-Indirect Object-2-Direct Object",
-          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 0 },
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": "0" },
+          width: 5, height: 5,
         },
         node.data.animation === "animate"
           ? {
-              id: node.id + "-actor",
-              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
-            }
+          id: node.id + "-actor",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "1" },
+          width: 5, height: 5,
+        }
           : {
-              id: node.id + "-outcome",
-              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
-            },
+          id: node.id + "-outcome",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "1" },
+          width: 5, height: 5,
+        },
       ]);
     case "Execution Constraint":
       return ports.concat([
         {
           id: node.parentId + "-Execution Constraint-2-Aim",
-          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 0 },
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": "0" },
+          width: 5, height: 5,
         },
         {
           id: node.id + "-actor",
-          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": "1" },
+          width: 5, height: 5,
         },
       ]);
     default:
@@ -149,17 +170,17 @@ const layoutOptions = {
 
   "elk.hierarchyHandling": "INCLUDE_CHILDREN",
   // "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
-  "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
+  // "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
   // "elk.layered.mergeEdges": "True",
-  "elk.layered.edgeRouting.splines.mode": "CONSERVATIVE",
+  // "elk.layered.edgeRouting.splines.mode": "CONSERVATIVE",
 
-  "elk.layered.layering.strategy": "LONGEST_PATH",
+  // "elk.layered.layering.strategy": "LONGEST_PATH",
   // "elk.layered.considerModelOrder.portModelOrder": true,
   // "elk.layered.considerModelOrder.crossingCounterPortInfluence": 0.001,
 
   // "elk.edgeRouting": "ORTHOGONAL",
   // "elk.layered.allowNonFlowPortsToSwitchSides": true,
-  "elk.layered.crossingMinimization.greedySwitchHierarchical.type": "TWO_SIDED",
+  // "elk.layered.crossingMinimization.greedySwitchHierarchical.type": "TWO_SIDED",
 } as const;
 
 export const useComponentLayout = () => {
@@ -194,42 +215,57 @@ export const useComponentLayout = () => {
                 "-2-" +
                 edge.source.replace(edge.data?.statementId + "-", "");
             }
-            return {
-              ...edge,
+            // TODO 
+            const elkedge: ElkExtendedEdge ={
+              id: edge.id,
               sources: [source],
               targets: [target],
             };
+            if (edge.label) {
+              elkedge.labels = [{ 
+                text: edge.label as string ,
+                layoutOptions: {
+                  // TODO label is placed right instead of center
+                  "elk.edgeLabels.placement": "CENTER",
+                }
+              }]
+            }
+            return elkedge;
           });
         return {
-          ...node,
+          id: node.id,
+          width: node.measured!.width,
+          height: node.measured!.height,
+          labels: [{ text: node.data.label }],
           children: getNodes()
             .filter((n) => n.parentId === node.id && !n.hidden)
             .map((component) => {
               const cports = computePorts(component);
               return {
-                ...component,
+                id: component.id,
                 width: component.measured!.width,
                 height: component.measured!.height,
+                // x: component.position?.x,
+                // y: component.position?.y,
                 labels: [{ text: component.data.label }],
                 layoutOptions: {
-                  "elk.direction": "RIGHT", // Components next to each other
+                  // "elk.direction": "RIGHT", // Components next to each other
                   "elk.portConstraints": "FIXED_ORDER",
-                  "elk.spacing.nodeNode": nodePadding.toString(),
-                  "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
-                  "elk.spacing.portPort": "10",
+                  // "elk.spacing.nodeNode": nodePadding.toString(),
+                  // "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
+                  // "elk.spacing.portPort": "10",
                   "nodeLabels.placement": "[INSIDE]",
                 },
                 ports: cports,
               };
             }),
-          width: node.measured!.width,
-          height: node.measured!.height,
           layoutOptions: {
-            "elk.direction": "RIGHT", // Components next to each other
+            // "elk.direction": "RIGHT", // Components next to each other
             "elk.portConstraints": "FIXED_ORDER",
-            "elk.spacing.nodeNode": nodePadding.toString(),
-            "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
-            "elk.spacing.portPort": "10",
+            // "elk.spacing.nodeNode": nodePadding.toString(),
+            // "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
+            // "elk.spacing.portPort": "10",
+            "elk.nodeLabels.placement": "[INSIDE]"
           },
           edges: componentEdges,
         };
@@ -250,7 +286,7 @@ export const useComponentLayout = () => {
               edge.source.replace(edge.data?.statementId + "-", "");
           }
           return {
-            ...edge,
+            id: edge.id,
             sources: [source],
             targets: [target],
           };
@@ -260,8 +296,11 @@ export const useComponentLayout = () => {
     console.log(JSON.stringify(graph));
     // @ts-expect-error copied from react-flow examples
     const layout = await elk.layout(graph);
-
     // console.log(JSON.stringify(layout))
+
+    // TODO copy positions and edge sections back to react-flow graph
+    return
+    
 
     const { children } = layout;
     // By mutating the children in-place we saves ourselves from creating a

--- a/src/components/LayoutButton.tsx
+++ b/src/components/LayoutButton.tsx
@@ -23,8 +23,8 @@ const layoutOptions = {
   "elk.direction": "RIGHT",
 } as const;
 
-const useComponentLayout = () => {
-  const { getNodes, setNodes, getEdges, fitView } = useReactFlow<
+export const useComponentLayout = () => {
+  const { getNodes, setNodes, getEdges, setEdges, fitView } = useReactFlow<
     INANode,
     INACEdge
   >();

--- a/src/components/LayoutButton.tsx
+++ b/src/components/LayoutButton.tsx
@@ -3,9 +3,9 @@ import { useReactFlow } from "@xyflow/react";
 import ELK from "elkjs/lib/elk-api";
 import ELKworker from "elkjs/lib/elk-worker.js?worker";
 import { LayoutTemplateIcon } from "lucide-react";
-import { isStatementNode } from "@/lib/node";
+import { isComponentNode, isStatementNode } from "@/lib/node";
 import type { INANode, StatementNode } from "@/lib/node";
-import { INASEdge, INACEdge } from "@/lib/edge";
+import { INASEdge, INACEdge, isComponentEdge } from "@/lib/edge";
 import { DropdownMenuItem } from "./ui/dropdown-menu";
 
 const elk = new ELK({
@@ -14,13 +14,152 @@ const elk = new ELK({
   },
 });
 
+type Port = {
+  id: string;
+  layoutOptions?: {
+    "elk.port.side"?: "WEST" | "EAST" | "NORTH" | "SOUTH";
+    "elk.port.index"?: number;
+  };
+};
+
+function computePorts(node: INANode) {
+  const ports: Port[] = [
+    // { id: node.id }
+  ];
+  if (!isComponentNode(node)) {
+    return ports;
+  }
+  switch (node.type) {
+    case "Activation Condition":
+      return ports.concat([
+        {
+          id: node.parentId + "-Activation Condition-2-Attribute",
+          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": 2 },
+        },
+        {
+          id: node.id + "-outcome",
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 0 },
+        },
+        {
+          id: node.id + "-sanction",
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 1 },
+        },
+      ]);
+    case "Attribute":
+      return ports.concat([
+        {
+          id: node.parentId + "-Attribute-2-Activation Condition",
+          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": 0 },
+        },
+        {
+          id: node.parentId + "-Attribute-2-Aim",
+          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": 1 },
+        },
+        {
+          id: node.id + "-actor",
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 2 },
+        },
+      ]);
+    case "Aim":
+      return ports.concat([
+        {
+          id: node.parentId + "-Aim-2-Attribute",
+          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": 2 },
+        },
+        {
+          id: node.parentId + "-Aim-2-Direct Object",
+          layoutOptions: { "elk.port.side": "EAST", "elk.port.index": 3 },
+        },
+        {
+          id: node.parentId + "-Aim-2-Execution Constraint",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 0 },
+        },
+        {
+          id: node.id + "-sanction",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+        },
+      ]);
+    case "Direct Object":
+      return ports.concat([
+        {
+          id: node.parentId + "-Direct Object-2-Aim",
+          layoutOptions: { "elk.port.side": "WEST", "elk.port.index": 2 },
+        },
+        {
+          id: node.parentId + "-Direct Object-2-Indirect Object",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 0 },
+        },
+        node.data.animation === "animate"
+          ? {
+              id: node.id + "-actor",
+              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+            }
+          : {
+              id: node.id + "-outcome",
+              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+            },
+      ]);
+    case "Indirect Object":
+      return ports.concat([
+        {
+          id: node.parentId + "-Indirect Object-2-Direct Object",
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 0 },
+        },
+        node.data.animation === "animate"
+          ? {
+              id: node.id + "-actor",
+              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+            }
+          : {
+              id: node.id + "-outcome",
+              layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+            },
+      ]);
+    case "Execution Constraint":
+      return ports.concat([
+        {
+          id: node.parentId + "-Execution Constraint-2-Aim",
+          layoutOptions: { "elk.port.side": "NORTH", "elk.port.index": 0 },
+        },
+        {
+          id: node.id + "-actor",
+          layoutOptions: { "elk.port.side": "SOUTH", "elk.port.index": 1 },
+        },
+      ]);
+    default:
+      throw new Error(`Unknown component type ${node.type}`);
+  }
+}
+
+/*
+ * https://rtsys.informatik.uni-kiel.de/elklive/models.html?link=realworld%2Fptolemy%2Fhierarchical%2Faspect_cartrackingattackmodeling_CarTrackingAttackModeling.json
+ * https://rtsys.informatik.uni-kiel.de/elklive/models.html?link=realworld%2Fptolemy%2Fhierarchical%2Ftm_mergedevents_MergedEvents.json
+ */
+
 // TODO make layout multi handle aware
 // see https://reactflow.dev/examples/layout/elkjs-multiple-handles
 const layoutOptions = {
   "elk.algorithm": "layered",
-  "elk.layered.spacing.nodeNodeBetweenLayers": 100,
-  "elk.spacing.nodeNode": 40,
-  "elk.direction": "RIGHT",
+  // "elk.layered.spacing.nodeNodeBetweenLayers": 100,
+
+  // "elk.spacing.nodeNode": 40,
+  // "elk.padding": "[top=20,left=20,bottom=20,right=20]",
+  // "elk.direction": "RIGHT",
+  // "elk.direction": "DOWN", // Statements underneat each other
+
+  "elk.hierarchyHandling": "INCLUDE_CHILDREN",
+  // "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+  "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
+  // "elk.layered.mergeEdges": "True",
+  "elk.layered.edgeRouting.splines.mode": "CONSERVATIVE",
+
+  "elk.layered.layering.strategy": "LONGEST_PATH",
+  // "elk.layered.considerModelOrder.portModelOrder": true,
+  // "elk.layered.considerModelOrder.crossingCounterPortInfluence": 0.001,
+
+  // "elk.edgeRouting": "ORTHOGONAL",
+  // "elk.layered.allowNonFlowPortsToSwitchSides": true,
+  "elk.layered.crossingMinimization.greedySwitchHierarchical.type": "TWO_SIDED",
 } as const;
 
 export const useComponentLayout = () => {
@@ -29,61 +168,142 @@ export const useComponentLayout = () => {
     INACEdge
   >();
 
-  const getLayoutedElements = useCallback(() => {
+  const getLayoutedElements = useCallback(async () => {
     const statementNodes = getNodes().filter(isStatementNode);
     const edges = getEdges();
+    const nodePadding = 15;
     const graph = {
       id: "root",
       layoutOptions: {
         ...layoutOptions,
-        "elk.direction": "RIGHT",
       },
       children: statementNodes.map((node) => {
+        const componentEdges = edges
+          .filter(isComponentEdge)
+          .filter((e) => e.data?.statementId === node.id)
+          .map((edge) => {
+            let source = edge.source + "-" + edge.type;
+            let target = edge.target + "-" + edge.type;
+            if (edge.type === "component") {
+              source =
+                edge.source +
+                "-2-" +
+                edge.target.replace(edge.data?.statementId + "-", "");
+              target =
+                edge.target +
+                "-2-" +
+                edge.source.replace(edge.data?.statementId + "-", "");
+            }
+            return {
+              ...edge,
+              sources: [source],
+              targets: [target],
+            };
+          });
         return {
           ...node,
           children: getNodes()
             .filter((n) => n.parentId === node.id && !n.hidden)
             .map((component) => {
+              const cports = computePorts(component);
               return {
                 ...component,
                 width: component.measured!.width,
                 height: component.measured!.height,
+                labels: [{ text: component.data.label }],
+                layoutOptions: {
+                  "elk.direction": "RIGHT", // Components next to each other
+                  "elk.portConstraints": "FIXED_ORDER",
+                  "elk.spacing.nodeNode": nodePadding.toString(),
+                  "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
+                  "elk.spacing.portPort": "10",
+                  "nodeLabels.placement": "[INSIDE]",
+                },
+                ports: cports,
               };
             }),
           width: node.measured!.width,
           height: node.measured!.height,
+          layoutOptions: {
+            "elk.direction": "RIGHT", // Components next to each other
+            "elk.portConstraints": "FIXED_ORDER",
+            "elk.spacing.nodeNode": nodePadding.toString(),
+            "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
+            "elk.spacing.portPort": "10",
+          },
+          edges: componentEdges,
         };
       }),
-      edges,
+      edges: edges
+        .filter((e) => !isComponentEdge(e))
+        .map((edge) => {
+          let source = edge.source + "-" + edge.type;
+          let target = edge.target + "-" + edge.type;
+          if (edge.type === "component") {
+            source =
+              edge.source +
+              "-2-" +
+              edge.target.replace(edge.data?.statementId + "-", "");
+            target =
+              edge.target +
+              "-2-" +
+              edge.source.replace(edge.data?.statementId + "-", "");
+          }
+          return {
+            ...edge,
+            sources: [source],
+            targets: [target],
+          };
+        }),
     };
 
+    console.log(JSON.stringify(graph));
     // @ts-expect-error copied from react-flow examples
-    elk.layout(graph).then(({ children }) => {
-      // By mutating the children in-place we saves ourselves from creating a
-      // needless copy of the nodes array.
-      const componentNodes: INANode[] = [];
-      children!.forEach((node) => {
+    const layout = await elk.layout(graph);
+
+    // console.log(JSON.stringify(layout))
+
+    const { children } = layout;
+    // By mutating the children in-place we saves ourselves from creating a
+    // needless copy of the nodes array.
+    const componentNodes: INANode[] = [];
+    children!.forEach((node) => {
+      // @ts-expect-error copied from react-flow examples
+      node.position = { x: node.x, y: node.y };
+      node.children!.forEach((component) => {
         // @ts-expect-error copied from react-flow examples
-        node.position = { x: node.x, y: node.y };
-        node.children!.forEach((component) => {
-          // @ts-expect-error copied from react-flow examples
-          component.position = {
-            x: component.x,
-            y: component.y,
-          };
-          // @ts-expect-error copied from react-flow examples
-          componentNodes.push(component);
-        });
-        node.children = undefined;
+        component.position = {
+          x: component.x,
+          y: component.y,
+        };
+        // @ts-expect-error copied from react-flow examples
+        componentNodes.push(component);
       });
+      node.children = undefined;
 
       // @ts-expect-error copied from react-flow examples
       setNodes([...children, ...componentNodes]);
+
+      const statementEdges = layout.edges!.map((e) => {
+        return {
+          ...e,
+          data: {
+            ...e.data,
+            bendPoints: e.sections![0].bendPoints,
+            startPoint: e.sections![0].startPoint,
+            endPoint: e.sections![0].endPoint,
+          },
+        };
+      });
+      const componentEdges = children!.flatMap((statement) => statement.edges);
+
+      setEdges([...statementEdges, ...componentEdges] as unknown as INACEdge[]);
+
       window.requestAnimationFrame(() => {
         fitView();
       });
     });
-  }, [fitView, getEdges, getNodes, setNodes]);
+  }, [fitView, getEdges, getNodes, setNodes, setEdges]);
 
   return getLayoutedElements;
 };

--- a/src/components/LayoutButton.tsx
+++ b/src/components/LayoutButton.tsx
@@ -165,7 +165,7 @@ const layoutOptions = {
 
   // "elk.spacing.nodeNode": 40,
   // "elk.padding": "[top=20,left=20,bottom=20,right=20]",
-  // "elk.direction": "RIGHT",
+  "elk.direction": "RIGHT",
   // "elk.direction": "DOWN", // Statements underneat each other
 
   "elk.hierarchyHandling": "INCLUDE_CHILDREN",
@@ -181,6 +181,7 @@ const layoutOptions = {
   // "elk.edgeRouting": "ORTHOGONAL",
   // "elk.layered.allowNonFlowPortsToSwitchSides": true,
   // "elk.layered.crossingMinimization.greedySwitchHierarchical.type": "TWO_SIDED",
+  "elk.layered.wrapping.strategy": "MULTI_EDGE"
 } as const;
 
 export const useComponentLayout = () => {
@@ -193,6 +194,7 @@ export const useComponentLayout = () => {
     const statementNodes = getNodes().filter(isStatementNode);
     const edges = getEdges();
     const nodePadding = 15;
+    let i= 0;
     const graph = {
       id: "root",
       layoutOptions: {
@@ -226,7 +228,7 @@ export const useComponentLayout = () => {
                 text: edge.label as string ,
                 layoutOptions: {
                   // TODO label is placed right instead of center
-                  "elk.edgeLabels.placement": "CENTER",
+                  // "elk.edgeLabels.placement": "CENTER",
                 }
               }]
             }
@@ -249,23 +251,25 @@ export const useComponentLayout = () => {
                 // y: component.position?.y,
                 labels: [{ text: component.data.label }],
                 layoutOptions: {
-                  // "elk.direction": "RIGHT", // Components next to each other
                   "elk.portConstraints": "FIXED_ORDER",
+                  // "elk.direction": "RIGHT", // Components next to each other
                   // "elk.spacing.nodeNode": nodePadding.toString(),
                   // "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
                   // "elk.spacing.portPort": "10",
-                  "nodeLabels.placement": "[INSIDE]",
+                  // "nodeLabels.placement": "[INSIDE]",
+
                 },
                 ports: cports,
               };
             }),
           layoutOptions: {
-            // "elk.direction": "RIGHT", // Components next to each other
             "elk.portConstraints": "FIXED_ORDER",
+            // "elk.direction": "RIGHT", // Components next to each other
             // "elk.spacing.nodeNode": nodePadding.toString(),
             // "elk.padding": `[top=${nodePadding},left=${nodePadding},bottom=${nodePadding},right=${nodePadding}]`,
             // "elk.spacing.portPort": "10",
-            "elk.nodeLabels.placement": "[INSIDE]"
+            // "elk.nodeLabels.placement": "[INSIDE]"
+            // "layering.layerChoiceConstraint": i++,
           },
           edges: componentEdges,
         };

--- a/src/components/LoadExampleButton.tsx
+++ b/src/components/LoadExampleButton.tsx
@@ -2,6 +2,7 @@ import { Connection, Statement } from "@/lib/schema";
 import { Button } from "./ui/button";
 import { Wand2Icon } from "lucide-react";
 import { store } from "@/stores/global";
+import { useEffect } from "react";
 
 const statements: Statement[] = [
   {
@@ -123,6 +124,19 @@ function loadExample() {
 }
 
 export function LoadExampleButton() {
+  // Add keyboard shortcut for clearing data
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "e") {
+        e.preventDefault();
+        loadExample();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <Button title="Load Example" variant="outline" onClick={loadExample}>
       <Wand2Icon /> Load Example

--- a/src/components/edges.tsx
+++ b/src/components/edges.tsx
@@ -13,6 +13,7 @@ import {
   getSmoothStepPath,
   Position,
 } from "@xyflow/react";
+import { ElkEdgeSection } from "elkjs/lib/elk-api";
 
 export function ComponentEdge({
   id,
@@ -21,7 +22,26 @@ export function ComponentEdge({
   targetX,
   targetY,
   label,
+  data,
 }: EdgeProps<ComponentEdge>) {
+  // if (data?.bendPoints) {
+  //   const bendPoints = data.bendPoints as ElkEdgeSection['bendPoints']
+  //   const points = [
+  //     // { x: sourceX, y: sourceY },
+  //     data.startPoint,
+  //     ...bendPoints!,
+  //     data.endPoint,
+  //     // { x: targetX, y: targetY },
+  //   ]
+  //   const edgePath = points.map(({ x, y }, index) => `${index === 0 ? "M" : "L"} ${x} ${y}`).join(" ");
+  //   return (
+  //     <BaseEdge
+  //       id={id}
+  //       path={edgePath}
+  //       label={label}
+  //     />
+  //   );
+  // }
   const [edgePath, labelX, labelY] = getStraightPath({
     sourceX,
     sourceY,
@@ -52,14 +72,31 @@ export function ActorDrivenConnection({
   targetX,
   targetY,
   markerEnd,
+  data,
 }: EdgeProps<ActorDrivenConnection>) {
+  // if (data?.bendPoints) {
+  //   const bendPoints = data.bendPoints as ElkEdgeSection['bendPoints']
+  //   const points = [
+  //     { x: sourceX, y: sourceY },
+  //     ...bendPoints!,
+  //     { x: targetX, y: targetY },
+  //   ]
+  //   const edgePath = points.map(({ x, y }, index) => `${index === 0 ? "M" : "L"} ${x} ${y}`).join(" ");
+  //   return (
+  //     <BaseEdge
+  //       id={id}
+  //       path={edgePath}
+  //       style={actorDrivenStyle}
+  //       markerEnd={markerEnd}
+  //     />
+  //   );
+  // }
   const [edgePath] = getSmoothStepPath({
     sourceX,
     sourceY,
     targetX,
     targetY,
   });
-
   return (
     <BaseEdge
       id={id}

--- a/src/routes/help.lazy.tsx
+++ b/src/routes/help.lazy.tsx
@@ -119,11 +119,12 @@ function RouteComponent() {
           <a href={screenshot} target="_blank" className="underline">
             Screenshot
           </a>{" "}
-          of web application with example loaded.
+          of web application with example loaded. Keyboard shortcut is
+          CTRL+SHIFT+e.
         </li>
         <li>
           <strong>Clear:</strong>To delete all statements and connections after
-          confirmation.
+          confirmation. Keyboard shortcut is CTRL+SHIFT+r.
         </li>
       </ul>
 
@@ -211,7 +212,7 @@ function RouteComponent() {
                 Layout:
               </strong>{" "}
               To layout the graph using a layout algorithm use the layout button
-              at the top right side.
+              at the top right side. Keyboard shortcut is CTRL+SHIFT+l.
             </li>
             <li>
               <strong>


### PR DESCRIPTION
Refs #150

To perform autolayout using keyboard shortcuts:
1. Clear: CTRL+SHIFT+r
2. Load example: CTRL+SHIFT+e
3. Auto layout component network:  CTRL+SHIFT+l

The input given to elk can be pruned and visualized on https://rtsys.informatik.uni-kiel.de/elklive/json.html

<details>
<summary>network with single statement and 2 components is working in visualizer
</summary>

```json
{
    "id": "root",
    "children": [
        {
            "id": "2",
            "labels": [
                        {
                            "text": "F2"
                        }
                    ],
                     "edges": [
        {
            "id": "2-activation-condition-2-attribute",
            "sources": [
                "2-Activation Condition-2-Attribute"
            ],
            "targets": [
                "2-Attribute-2-Activation Condition"
            ]
        }
    ],
            "children": [
                {
                    "id": "2-Attribute",
                    "width": 89,
                    "height": 42,
                    "labels": [
                        {
                            "text": "Governor"
                        }
                    ],
                    "layoutOptions": {
                        "elk.portConstraints": "FIXED_ORDER",
                        "nodeLabels.placement": "[INSIDE]"
                    },
                    "ports": [
                        {
                            "id": "2-Attribute-2-Activation Condition",
                            "layoutOptions": {
                                "elk.port.side": "WEST",
                                "elk.port.index": 0
                            },
                            "width":5,
                            "height": 5
                        }
                    ]
                },
                {
                    "id": "2-Activation Condition",
                    "width": 192,
                    "height": 80,
                    "labels": [
                        {
                            "text": "if requested by Prime minister"
                        }
                    ],
                    "layoutOptions": {
                        "elk.portConstraints": "FIXED_ORDER",
                        "nodeLabels.placement": "[INSIDE]"
                    },
                    "ports": [
                        {
                            "id": "2-Activation Condition-2-Attribute",
                            "layoutOptions": {
                                "elk.port.side": "EAST",
                                "elk.port.index": "2"
                            },
                            "width":5,
                            "height": 5
                        }
                    ]
                }
            ],
            "width": 814,
            "height": 478,
            "layoutOptions": {
                "elk.portConstraints": "FIXED_ORDER",
                "elk.direction": "RIGHT",
                "nodeLabels.placement": "[INSIDE]"
            }
        }
    ],
   
}
```

</details>

example not working:
[elkified.example.json](https://github.com/user-attachments/files/19469746/elkified.example.json)

TODO
- [ ] make edge take shortest past instead of staircasing
- [ ] render path generated by elk, see https://github.com/egraphs-good/egraph-visualizer/blob/2c7e96ebdf53b8c3690f4f729a46ae69ecbbf70e/src/Visualizer.tsx#L347-L351 for inspiration
- [ ] given auto layout completed then moving nodes should wipe the edge path from elk

NICE
- [ ] ability to run auto layout on selection
- [ ] ability to run auto layout continuously, so when moving nodes manually the edge route gets re-calculated by elk.js
