### PR TITLE
Use libavoid to route edges around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dist-ssr
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# wasm from libavoid-js
+/public/libavoid.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ dist-ssr
 /playwright/.cache/
 
 # wasm from libavoid-js
-/public/libavoid.wasm
+/src/lib/reroute/libavoid.wasm

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ina-tool",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-checkbox": "^1.1.4",
@@ -31,6 +32,7 @@
         "elkjs": "^0.9.3",
         "file-saver": "^2.0.5",
         "html-to-image": "^1.11.11",
+        "libavoid-js": "^0.4.4",
         "lucide-react": "^0.471.1",
         "next-themes": "^0.4.5",
         "react": "^18.3.1",
@@ -5832,6 +5834,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libavoid-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/libavoid-js/-/libavoid-js-0.4.4.tgz",
+      "integrity": "sha512-4FrxNE9c48kya4LqHX6+etHX6c/E2o7zkYoqlhpK2xhiS/If9yiP8BxUdBJpd8X5QgsArk7ayzXeTxcPhIgI9g==",
+      "license": "LGPL-2.1-or-later"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "format:check": "prettier --check .",
-    "copy:wasm": "mkdir -p public && cp node_modules/libavoid-js/dist/libavoid.wasm public/",
+    "copy:wasm": "cp node_modules/libavoid-js/dist/libavoid.wasm src/lib/reroute/",
     "postinstall": "npm run copy:wasm",
     "test": "vitest",
     "test:e2e": "playwright test"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "format:check": "prettier --check .",
+    "copy:wasm": "mkdir -p public && cp node_modules/libavoid-js/dist/libavoid.wasm public/",
+    "postinstall": "npm run copy:wasm",
     "test": "vitest",
     "test:e2e": "playwright test"
   },
@@ -38,6 +40,7 @@
     "elkjs": "^0.9.3",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.11.11",
+    "libavoid-js": "^0.4.4",
     "lucide-react": "^0.471.1",
     "next-themes": "^0.4.5",
     "react": "^18.3.1",

--- a/src/components/ComponentNetworkMenu.tsx
+++ b/src/components/ComponentNetworkMenu.tsx
@@ -1,4 +1,10 @@
-import { DownloadIcon, MenuIcon } from "lucide-react";
+import {
+  DownloadIcon,
+  FlaskConicalIcon,
+  MenuIcon,
+  RouteIcon,
+  RouteOffIcon,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,8 +26,12 @@ import { store } from "@/stores/global";
 import { ComponentLayoutButton, useComponentLayout } from "./LayoutButton";
 import { ScreenshotButton } from "./ScreenshotButton";
 import { useEffect } from "react";
-import { reRouteConnectionsOfComponentNetwork } from "@/lib/reroute";
+import {
+  reRouteConnections,
+  undoReroutedConnections,
+} from "@/lib/reroute/component";
 import { useReactFlow } from "@xyflow/react";
+import { toast } from "sonner";
 
 function exportAsGraphml() {
   const projectName = store.getState().projectName;
@@ -60,7 +70,7 @@ export function ComponentNetworkMenu() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "c") {
         e.preventDefault();
-        reRouteConnectionsOfComponentNetwork(reactFlow);
+        reRouteConnections(reactFlow);
       }
     };
 
@@ -89,12 +99,36 @@ export function ComponentNetworkMenu() {
             </DropdownMenuSubContent>
           </DropdownMenuPortal>
         </DropdownMenuSub>
-        <ComponentLayoutButton />
-        <DropdownMenuItem
-          onClick={() => reRouteConnectionsOfComponentNetwork(reactFlow)}
-        >
-          Re-route connections
-        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <FlaskConicalIcon />
+            Experimental
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              <ComponentLayoutButton />
+              <DropdownMenuItem
+                onClick={() => {
+                  toast.promise(reRouteConnections(reactFlow), {
+                    loading: "Rerouting connections...",
+                    success: "Connections rerouted",
+                    error: (err) => {
+                      console.error(err);
+                      return "Error rerouting connections";
+                    },
+                  });
+                }}
+              >
+                <RouteIcon />
+                Re-route connections
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={undoReroutedConnections}>
+                <RouteOffIcon />
+                Undo rerouted connections
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/ComponentNetworkMenu.tsx
+++ b/src/components/ComponentNetworkMenu.tsx
@@ -20,6 +20,8 @@ import { store } from "@/stores/global";
 import { ComponentLayoutButton, useComponentLayout } from "./LayoutButton";
 import { ScreenshotButton } from "./ScreenshotButton";
 import { useEffect } from "react";
+import { reRouteConnectionsOfComponentNetwork } from "@/lib/reroute";
+import { useReactFlow } from "@xyflow/react";
 
 function exportAsGraphml() {
   const projectName = store.getState().projectName;
@@ -40,6 +42,7 @@ function exportAsGexf() {
 }
 
 export function ComponentNetworkMenu() {
+  const reactFlow = useReactFlow();
   const autoLayout = useComponentLayout();
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -52,6 +55,18 @@ export function ComponentNetworkMenu() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [autoLayout]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        reRouteConnectionsOfComponentNetwork(reactFlow);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [reactFlow]);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -75,6 +90,11 @@ export function ComponentNetworkMenu() {
           </DropdownMenuPortal>
         </DropdownMenuSub>
         <ComponentLayoutButton />
+        <DropdownMenuItem
+          onClick={() => reRouteConnectionsOfComponentNetwork(reactFlow)}
+        >
+          Re-route connections
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/ComponentNetworkMenu.tsx
+++ b/src/components/ComponentNetworkMenu.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -32,6 +33,7 @@ import {
 } from "@/lib/reroute/component";
 import { useReactFlow } from "@xyflow/react";
 import { toast } from "sonner";
+import { Link } from "@tanstack/react-router";
 
 function exportAsGraphml() {
   const projectName = store.getState().projectName;
@@ -106,6 +108,12 @@ export function ComponentNetworkMenu() {
           </DropdownMenuSubTrigger>
           <DropdownMenuPortal>
             <DropdownMenuSubContent>
+              <DropdownMenuItem asChild>
+                <Link to="/help" hash="experimental-component">
+                  Please read help for usage
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <ComponentLayoutButton />
               <DropdownMenuItem
                 onClick={() => {

--- a/src/components/LayoutButton.tsx
+++ b/src/components/LayoutButton.tsx
@@ -7,7 +7,11 @@ import type { INANode, StatementNode } from "@/lib/node";
 import { INASEdge, INACEdge } from "@/lib/edge";
 import { DropdownMenuItem } from "./ui/dropdown-menu";
 import { applyLayoutToReactFlow, reactflow2elk } from "@/lib/elk";
-import { store } from "@/stores/component-network";
+import {
+  store,
+  reset as resetComponentNetwork,
+} from "@/stores/component-network";
+import { reset as resetStatementNetwork } from "@/stores/statement-network";
 
 const elk = new ELK({
   workerFactory: () => {
@@ -19,7 +23,7 @@ const elk = new ELK({
 export const useComponentLayout = () => {
   const { getNodes, getEdges, fitView } = useReactFlow<INANode, INACEdge>();
 
-  const getLayoutedElements = useCallback(() => {
+  const autoLayout = useCallback(() => {
     const state = {
       nodes: getNodes(),
       edges: getEdges(),
@@ -39,7 +43,7 @@ export const useComponentLayout = () => {
     });
   }, [fitView, getEdges, getNodes]);
 
-  return getLayoutedElements;
+  return autoLayout;
 };
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -89,19 +93,39 @@ export function useStatementLayout() {
 export function ComponentLayoutButton() {
   const autoLayout = useComponentLayout();
   return (
-    <DropdownMenuItem onClick={autoLayout} title="Auto layout nodes">
-      <LayoutTemplateIcon />
-      Auto layout
-    </DropdownMenuItem>
+    <>
+      <DropdownMenuItem onClick={autoLayout} title="Auto layout nodes">
+        <LayoutTemplateIcon />
+        Auto layout
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onClick={() => {
+          resetComponentNetwork();
+        }}
+        title="Reset component network"
+      >
+        <LayoutTemplateIcon /> Reset auto layout
+      </DropdownMenuItem>
+    </>
   );
 }
 
 export function StatementLayoutButton() {
   const autoLayout = useStatementLayout();
   return (
-    <DropdownMenuItem onClick={autoLayout} title="Auto layout nodes">
-      <LayoutTemplateIcon />
-      Auto layout
-    </DropdownMenuItem>
+    <>
+      <DropdownMenuItem onClick={autoLayout} title="Auto layout nodes">
+        <LayoutTemplateIcon />
+        Auto layout
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onClick={() => {
+          resetStatementNetwork();
+        }}
+        title="Reset auto layout"
+      >
+        <LayoutTemplateIcon /> Reset auto layout
+      </DropdownMenuItem>
+    </>
   );
 }

--- a/src/components/StatementNetworkMenu.tsx
+++ b/src/components/StatementNetworkMenu.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -32,6 +33,7 @@ import {
   reRouteConnections,
   undoReroutedConnections,
 } from "@/lib/reroute/statement";
+import { Link } from "@tanstack/react-router";
 
 function exportAsGraphml() {
   const projectName = store.getState().projectName;
@@ -106,6 +108,12 @@ export function StatementNetworkMenu() {
           </DropdownMenuSubTrigger>
           <DropdownMenuPortal>
             <DropdownMenuSubContent>
+              <DropdownMenuItem asChild>
+                <Link to="/help" hash="experimental-statement">
+                  Please read help for usage
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <StatementLayoutButton />
               <DropdownMenuItem
                 onClick={() => {

--- a/src/components/StatementNetworkMenu.tsx
+++ b/src/components/StatementNetworkMenu.tsx
@@ -1,4 +1,10 @@
-import { DownloadIcon, MenuIcon } from "lucide-react";
+import {
+  DownloadIcon,
+  FlaskConicalIcon,
+  MenuIcon,
+  RouteIcon,
+  RouteOffIcon,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +26,12 @@ import { store } from "@/stores/global";
 import { StatementLayoutButton, useStatementLayout } from "./LayoutButton";
 import { ScreenshotButton } from "./ScreenshotButton";
 import { useEffect } from "react";
+import { toast } from "sonner";
+import { useReactFlow } from "@xyflow/react";
+import {
+  reRouteConnections,
+  undoReroutedConnections,
+} from "@/lib/reroute/statement";
 
 function exportAsGraphml() {
   const projectName = store.getState().projectName;
@@ -40,6 +52,7 @@ function exportAsGexf() {
 }
 
 export function StatementNetworkMenu() {
+  const reactFlow = useReactFlow();
   const autoLayout = useStatementLayout();
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -52,6 +65,18 @@ export function StatementNetworkMenu() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [autoLayout]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        reRouteConnections(reactFlow);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [reactFlow]);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -74,7 +99,36 @@ export function StatementNetworkMenu() {
             </DropdownMenuSubContent>
           </DropdownMenuPortal>
         </DropdownMenuSub>
-        <StatementLayoutButton />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <FlaskConicalIcon />
+            Experimental
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              <StatementLayoutButton />
+              <DropdownMenuItem
+                onClick={() => {
+                  toast.promise(reRouteConnections(reactFlow), {
+                    loading: "Rerouting connections...",
+                    success: "Connections rerouted",
+                    error: (err) => {
+                      console.error(err);
+                      return "Error rerouting connections";
+                    },
+                  });
+                }}
+              >
+                <RouteIcon />
+                Re-route connections
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={undoReroutedConnections}>
+                <RouteOffIcon />
+                Undo rerouted connections
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/edges.tsx
+++ b/src/components/edges.tsx
@@ -124,9 +124,9 @@ function BaseEdgeWithDelete({
   let [edgePath, labelX, labelY] = ["", 0, 0];
   if (data?.bends && Array.isArray(data.bends)) {
     [edgePath, labelX, labelY] = getBendyPath([
-      [sourceX, sourceY],
+      [endpoints.sourceX, endpoints.sourceY],
       ...data.bends,
-      [targetX, targetY],
+      [endpoints.targetX, endpoints.targetY],
     ]);
   } else {
     [edgePath, labelX, labelY] = getSmoothStepPath(endpoints);
@@ -138,12 +138,7 @@ function BaseEdgeWithDelete({
 
   return (
     <>
-      <BaseEdge
-        id={id}
-        path={edgePath}
-        style={style}
-        markerEnd={markerEnd}
-      />
+      <BaseEdge id={id} path={edgePath} style={style} markerEnd={markerEnd} />
       {isInteractive && (
         <EdgeLabelRenderer>
           <div

--- a/src/components/edges.tsx
+++ b/src/components/edges.tsx
@@ -95,6 +95,8 @@ function computeAvoidedPath(
     const Avoid = AvoidLib.getInstance();
     const router = new Avoid.Router(Avoid.OrthogonalRouting);
     const pad = 2;
+    let sx = 0;
+    let sy = 0;
     for (const node of nodes) {
       if (isComponentNode(node)) {
         // Exclude component nodes
@@ -107,16 +109,44 @@ function computeAvoidedPath(
       if (!node.measured) {
         continue;
       }
-      new Avoid.ShapeRef(
-        router,
-        new Avoid.Rectangle(
-          new Avoid.Point(node.position.x - pad, node.position.y - pad),
-          new Avoid.Point(
-            node.position.x + node.measured.width! + pad,
-            node.position.y + node.measured.height! + pad,
-          ),
-        ),
+      console.log(
+        JSON.stringify({
+          i: node.id,
+          x: node.position.x,
+          y: node.position.y,
+          w: node.measured.width,
+          h: node.measured.height,
+          d: node.data,
+        }),
       );
+      if (isStatementNode(node)) {
+        sx = node.position.x;
+        sy = node.position.y;
+        new Avoid.ShapeRef(
+          router,
+          new Avoid.Rectangle(
+            new Avoid.Point(node.position.x - pad, node.position.y - pad),
+            new Avoid.Point(
+              node.position.x + node.measured.width! + pad,
+              node.position.y + node.measured.height! + pad,
+            ),
+          ),
+        );
+      } else {
+        new Avoid.ShapeRef(
+          router,
+          new Avoid.Rectangle(
+            new Avoid.Point(
+              node.position.x - pad + sx,
+              node.position.y - pad + sy,
+            ),
+            new Avoid.Point(
+              node.position.x + node.measured.width! + pad + sy,
+              node.position.y + node.measured.height! + pad + sy,
+            ),
+          ),
+        );
+      }
     }
     const connRef = new Avoid.ConnRef(
       router,

--- a/src/components/edges.tsx
+++ b/src/components/edges.tsx
@@ -28,7 +28,7 @@ import { useCallback, useEffect } from "react";
 import { conflict2id } from "@/stores/component-network";
 import { XIcon } from "lucide-react";
 import { AvoidLib } from "libavoid-js";
-import { INANode, isComponentNode, isStatementNode } from "@/lib/node";
+import { INANode, isStatementNode } from "@/lib/node";
 
 const COMPONENT_HANDLE_SIZE = 4;
 const DRIVEN_CONNECTION_HANDLE_SIZE = 5;
@@ -88,7 +88,6 @@ export function useLibAvoid() {
 function computeAvoidedPath(
   endpoints: EndPoints,
   nodes: INANode[],
-  id: string,
 ): [string, number, number] {
   try {
     // TODO make lazy, do not reconstruct avoid router every time
@@ -98,27 +97,9 @@ function computeAvoidedPath(
     let sx = 0;
     let sy = 0;
     for (const node of nodes) {
-      if (isComponentNode(node)) {
-        // Exclude component nodes
-        // continue;
-      }
-      if (isStatementNode(node) && id.includes(node.id)) {
-        // Exclude statement nodes which are part of the edge
-        // continue;
-      }
       if (!node.measured) {
         continue;
       }
-      console.log(
-        JSON.stringify({
-          i: node.id,
-          x: node.position.x,
-          y: node.position.y,
-          w: node.measured.width,
-          h: node.measured.height,
-          d: node.data,
-        }),
-      );
       if (isStatementNode(node)) {
         sx = node.position.x;
         sy = node.position.y;
@@ -223,7 +204,7 @@ function BaseEdgeWithDelete({
   const isInteractive = useIsInteractive();
 
   const nodes = useNodes<INANode>();
-  const [edgePath, labelX, labelY] = computeAvoidedPath(endpoints, nodes, id);
+  const [edgePath, labelX, labelY] = computeAvoidedPath(endpoints, nodes);
 
   const deleteConnection = useCallback(() => {
     onDelete(id);

--- a/src/hooks/use-interactive.ts
+++ b/src/hooks/use-interactive.ts
@@ -8,7 +8,7 @@ export function useIsInteractive() {
   return useStore(selector, shallow);
 }
 
-interface EndPoints {
+export interface EndPoints {
   sourceX: number;
   sourceY: number;
   targetX: number;

--- a/src/lib/edge.ts
+++ b/src/lib/edge.ts
@@ -19,14 +19,22 @@ export type ComponentEdge = Edge<
   { label?: string; statementId: string },
   "component"
 >;
-export type ActorDrivenConnection = Edge<Record<string, unknown>, "actor">; // Purple
-export type OutcomeDrivenConnection = Edge<Record<string, unknown>, "outcome">; // Green
+
+type Bend = [number, number];
+type Bends = Bend[];
+
+type BendData = {
+  bends?: Bends;
+};
+
+export type ActorDrivenConnection = Edge<BendData, "actor">; // Purple
+export type OutcomeDrivenConnection = Edge<BendData, "outcome">; // Green
 export type SanctionDrivenConnection = Edge<
   Record<string, unknown>,
   "sanction"
 >; // Red
 
-export type ConflictingEdge = Edge<Record<string, unknown>, "conflict">;
+export type ConflictingEdge = Edge<BendData, "conflict">;
 
 export type DrivenConnectionEdge =
   | ActorDrivenConnection

--- a/src/lib/edge.ts
+++ b/src/lib/edge.ts
@@ -21,7 +21,7 @@ export type ComponentEdge = Edge<
 >;
 
 type Bend = [number, number];
-type Bends = Bend[];
+export type Bends = Bend[];
 
 type BendData = {
   bends?: Bends;

--- a/src/lib/elk.ts
+++ b/src/lib/elk.ts
@@ -27,14 +27,8 @@ type Port = {
   height?: number;
 };
 
-function computePorts(node: INANode) {
-  const ports: Port[] = [
-    // { id: node.id }
-  ];
-  if (!isComponentNode(node)) {
-    // TODO add conflict ports
-    return ports;
-  }
+function computePorts(node: ComponentNode) {
+  const ports: Port[] = [];
   switch (node.type) {
     case "Activation Condition":
       return ports.concat([
@@ -259,10 +253,31 @@ function statementNodeToElk(statement: INANode, reactflow: State): ElkNode {
     },
     children,
     edges,
+    ports: [
+      {
+        id: statement.id + "-conflict-target",
+        layoutOptions: { "elk.port.side": "WEST", "elk.port.index": "0" },
+        width: 5,
+        height: 5,
+      },
+      {
+        id: statement.id + "-conflict-source",
+        layoutOptions: { "elk.port.side": "EAST", "elk.port.index": "0" },
+        width: 5,
+        height: 5,
+      },
+    ],
   };
 }
 
 function statementEdgeToElk(edge: INASEdge): ElkExtendedEdge {
+  if (edge.type === "conflict") {
+    return {
+      id: edge.id,
+      sources: [edge.source + "-conflict-source"],
+      targets: [edge.target + "-conflict-target"],
+    };
+  }
   return {
     id: edge.id,
     sources: [edge.source + "-" + edge.type],

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,4 +1,4 @@
-import { INACEdge, INASEdge } from "./edge";
+import { INACEdge, INASEdge, isComponentEdge } from "./edge";
 import { INANode, StatementNode } from "./node";
 import { Statement } from "./schema";
 
@@ -155,7 +155,9 @@ export function exportComponentNetworkToGraphml(
         </node>
       `);
     }
-    for (const edge of edges.filter((e) => e.data?.statementId === node.id)) {
+    for (const edge of edges.filter(
+      (e) => isComponentEdge(e) && e.data?.statementId === node.id,
+    )) {
       xmlParts.push(
         `<edge id="${edge.id}" source="${edge.source}" target="${edge.target}">`,
       );
@@ -172,7 +174,7 @@ export function exportComponentNetworkToGraphml(
       </node>
     `);
   }
-  for (const edge of edges.filter((e) => !e.data?.statementId)) {
+  for (const edge of edges.filter((e) => !isComponentEdge(e))) {
     xmlParts.push(`
       <edge id="${edge.id}" source="${edge.source}" target="${edge.target}">
       <data key="etype">${edge.type}</data>

--- a/src/lib/reroute.ts
+++ b/src/lib/reroute.ts
@@ -1,0 +1,128 @@
+import { store as networkStore } from "@/stores/component-network";
+import { Avoid, AvoidLib } from "libavoid-js";
+import { isStatementNode } from "./node";
+import { ConnectionMode, EdgeChange, getEdgePosition } from "@xyflow/system";
+import {
+  INACEdge,
+  isComponentEdge,
+  isConflictingEdge,
+  isDrivenConnectionEdge,
+} from "./edge";
+import { ReactFlowInstance } from "@xyflow/react";
+
+export function reRouteConnectionsOfComponentNetwork(
+  reactflow: ReactFlowInstance,
+) {
+  const nodes = networkStore.getState().nodes;
+  const nodeLookup = new Map(
+    nodes.map((node) => [node.id, reactflow.getInternalNode(node.id)!]),
+  );
+
+  const Avoid = AvoidLib.getInstance();
+  const router = new Avoid.Router(Avoid.OrthogonalRouting);
+  const pad = 2;
+  let sx = 0;
+  let sy = 0;
+  for (const node of nodes) {
+    if (!node.measured) {
+      continue;
+    }
+    if (isStatementNode(node)) {
+      sx = node.position.x;
+      sy = node.position.y;
+      new Avoid.ShapeRef(
+        router,
+        new Avoid.Rectangle(
+          new Avoid.Point(node.position.x - pad, node.position.y - pad),
+          new Avoid.Point(
+            node.position.x + node.measured.width! + pad,
+            node.position.y + node.measured.height! + pad,
+          ),
+        ),
+      );
+    } else {
+      new Avoid.ShapeRef(
+        router,
+        new Avoid.Rectangle(
+          new Avoid.Point(
+            node.position.x - pad + sx,
+            node.position.y - pad + sy,
+          ),
+          new Avoid.Point(
+            node.position.x + node.measured.width! + pad + sy,
+            node.position.y + node.measured.height! + pad + sy,
+          ),
+        ),
+      );
+    }
+  }
+
+  const edges = networkStore.getState().edges;
+  const routes = new Map<string, Avoid["ConnRef"]>();
+  for (const edge of edges) {
+    if (isComponentEdge(edge)) {
+      continue;
+    }
+    const sourceNode = nodeLookup.get(edge.source);
+    const targetNode = nodeLookup.get(edge.target);
+    if (!sourceNode || !targetNode) {
+      throw new Error(
+        `Could not find source or target node for edge ${edge.id}`,
+      );
+    }
+    if (
+      typeof edge.sourceHandle !== "string" ||
+      typeof edge.targetHandle !== "string"
+    ) {
+      throw new Error(`Handles are not valid`);
+    }
+    const ep = getEdgePosition({
+      id: edge.id,
+      sourceNode,
+      sourceHandle: edge.sourceHandle,
+      targetNode,
+      targetHandle: edge.targetHandle,
+      connectionMode: ConnectionMode.Loose,
+    });
+    console.log("ep", ep);
+    if (ep === null) {
+      throw new Error(
+        `Could not find edge position for edge ${edge.id} from ${edge.source} to ${edge.target}`,
+      );
+    }
+    const connRef = new Avoid.ConnRef(
+      router,
+      new Avoid.ConnEnd(new Avoid.Point(ep.sourceX, ep.sourceY)),
+      new Avoid.ConnEnd(new Avoid.Point(ep.targetX, ep.targetY)),
+    );
+    routes.set(edge.id, connRef);
+  }
+  router.processTransaction();
+  const changes: EdgeChange<INACEdge>[] = [];
+  for (const [edgeId, connRef] of routes.entries()) {
+    const route = connRef.displayRoute();
+    const nrPoints = route.size();
+    const points = [];
+    for (let i = 0; i < nrPoints; i++) {
+      const point = route.get_ps(i);
+      points.push([point.x, point.y]);
+    }
+    // A edge component already knows it source and target position,
+    // so do not store them here
+    const bends = points.slice(1, -1);
+    const edge = edges
+      .filter((e) => isDrivenConnectionEdge(e) || isConflictingEdge(e))
+      .find((edge) => edge.id === edgeId)!;
+    changes.push({
+      id: edgeId,
+      type: "replace",
+      item: {
+        ...edge,
+        data: {
+          bends,
+        },
+      },
+    });
+  }
+  networkStore.getState().onEdgesChange(changes);
+}

--- a/src/lib/reroute/component.ts
+++ b/src/lib/reroute/component.ts
@@ -1,0 +1,55 @@
+import { EdgeChange } from "@xyflow/system";
+import { ReactFlowInstance } from "@xyflow/react";
+
+import { store as networkStore } from "@/stores/component-network";
+import { INACEdge, isComponentEdge } from "../edge";
+import RerouteWorker from "./worker?worker";
+
+export async function reRouteConnections(reactflow: ReactFlowInstance) {
+  const nodes = networkStore.getState().nodes;
+  const nodeLookup = new Map(
+    nodes.map((node) => [node.id, reactflow.getInternalNode(node.id)!]),
+  );
+  const edges = networkStore.getState().edges;
+
+  const worker = new RerouteWorker();
+  return new Promise<void>((resolve) => {
+    worker.onmessage = (event) => {
+      const changes = event.data;
+      networkStore.getState().onEdgesChange(changes);
+      resolve();
+    };
+    worker.onerror = (error) => {
+      console.error("Worker error:", error);
+      worker.terminate();
+      resolve();
+    };
+
+    worker.postMessage({
+      nodes,
+      edges,
+      nodeLookup,
+    });
+  });
+}
+
+export function undoReroutedConnections() {
+  const changes: EdgeChange<INACEdge>[] = [];
+  const edges = networkStore.getState().edges;
+  for (const edge of edges) {
+    if (!isComponentEdge(edge) && edge.data?.bends) {
+      const item = {
+        ...edge,
+        data: {
+          bends: undefined,
+        },
+      } as INACEdge;
+      changes.push({
+        id: edge.id,
+        type: "replace",
+        item,
+      });
+    }
+  }
+  networkStore.getState().onEdgesChange(changes);
+}

--- a/src/lib/reroute/rerouter.ts
+++ b/src/lib/reroute/rerouter.ts
@@ -27,13 +27,16 @@ export async function reroute({
   const router = new Avoid.Router(Avoid.OrthogonalRouting);
   const pad = 2;
   // capture statement node positions as component position is relative to the statement node
-  const statementNodePositions = new Map<string, {x: number, y: number}>();
+  const statementNodePositions = new Map<string, { x: number; y: number }>();
   for (const node of nodes) {
     if (!node.measured) {
       continue;
     }
     if (isStatementNode(node)) {
-      statementNodePositions.set(node.id, {x: node.position.x, y: node.position.y});
+      statementNodePositions.set(node.id, {
+        x: node.position.x,
+        y: node.position.y,
+      });
     }
   }
   for (const node of nodes) {
@@ -41,7 +44,10 @@ export async function reroute({
       continue;
     }
     if (isComponentNode(node)) {
-      const {x:sx, y: sy} = statementNodePositions.get(node.parentId!) || {x: 0, y: 0};
+      const { x: sx, y: sy } = statementNodePositions.get(node.parentId!) || {
+        x: 0,
+        y: 0,
+      };
       new Avoid.ShapeRef(
         router,
         new Avoid.Rectangle(

--- a/src/lib/reroute/statement.ts
+++ b/src/lib/reroute/statement.ts
@@ -1,0 +1,55 @@
+import { EdgeChange } from "@xyflow/system";
+import { ReactFlowInstance } from "@xyflow/react";
+
+import { store as networkStore } from "@/stores/statement-network";
+import { INASEdge, isComponentEdge } from "../edge";
+import RerouteWorker from "./worker?worker";
+
+export async function reRouteConnections(reactflow: ReactFlowInstance) {
+  const nodes = networkStore.getState().nodes;
+  const nodeLookup = new Map(
+    nodes.map((node) => [node.id, reactflow.getInternalNode(node.id)!]),
+  );
+  const edges = networkStore.getState().edges;
+
+  const worker = new RerouteWorker();
+  return new Promise<void>((resolve) => {
+    worker.onmessage = (event) => {
+      const changes = event.data;
+      networkStore.getState().onEdgesChange(changes);
+      resolve();
+    };
+    worker.onerror = (error) => {
+      console.error("Worker error:", error);
+      worker.terminate();
+      resolve();
+    };
+
+    worker.postMessage({
+      nodes,
+      edges,
+      nodeLookup,
+    });
+  });
+}
+
+export function undoReroutedConnections() {
+  const changes: EdgeChange<INASEdge>[] = [];
+  const edges = networkStore.getState().edges;
+  for (const edge of edges) {
+    if (!isComponentEdge(edge) && edge.data?.bends) {
+      const item = {
+        ...edge,
+        data: {
+          bends: undefined,
+        },
+      } as INASEdge;
+      changes.push({
+        id: edge.id,
+        type: "replace",
+        item,
+      });
+    }
+  }
+  networkStore.getState().onEdgesChange(changes);
+}

--- a/src/lib/reroute/worker.ts
+++ b/src/lib/reroute/worker.ts
@@ -1,0 +1,7 @@
+import { reroute } from "./rerouter";
+
+onmessage = async (event: MessageEvent) => {
+  const { data } = event;
+  const changes = await reroute(data);
+  postMessage(changes);
+};

--- a/src/routes/help.lazy.tsx
+++ b/src/routes/help.lazy.tsx
@@ -11,6 +11,7 @@ import {
   DownloadIcon,
   EyeOff,
   FilterXIcon,
+  FlaskConicalIcon,
   LayoutTemplateIcon,
   LinkIcon,
   Maximize2Icon,
@@ -18,6 +19,8 @@ import {
   PanelLeft,
   PencilIcon,
   PlusIcon,
+  RouteIcon,
+  RouteOffIcon,
   SaveIcon,
   SearchIcon,
   TrashIcon,
@@ -268,10 +271,36 @@ function RouteComponent() {
             </li>
             <li>
               <strong>
-                <LayoutTemplateIcon className="inline" /> Auto layout:
+                <FlaskConicalIcon className="inline" />
+                Experimental
               </strong>{" "}
-              To layout the graph using a layout algorithm use the auto layout
-              menu item. Keyboard shortcut is CTRL+SHIFT+l.
+              Experimental features, they have some rough edges, but can be
+              useful. Use at your own risk.
+              <ul className="ml-6 list-inside list-disc">
+                <li>
+                  <strong>
+                    <LayoutTemplateIcon className="inline" /> Auto layout:
+                  </strong>{" "}
+                  To layout the graph using a layout algorithm use the auto
+                  layout menu item. Keyboard shortcut is CTRL+SHIFT+l.
+                </li>
+                <li>
+                  <strong>
+                    <RouteIcon className="inline" /> Re-route connections:
+                  </strong>{" "}
+                  Re-route connections so they avoid most nodes. Moving nodes
+                  after re-routing will pin the inner bends of the connections.
+                  Keyboard shortcut is CTRL+SHIFT+c.
+                </li>
+                <li>
+                  <strong>
+                    <RouteOffIcon className="inline" />
+                    Undo rerouted connections
+                  </strong>
+                  {""}
+                  Will make whole connection move with nodes again.
+                </li>
+              </ul>
             </li>
           </ul>
         </li>
@@ -408,10 +437,36 @@ function RouteComponent() {
             </li>
             <li>
               <strong>
-                <LayoutTemplateIcon className="inline" /> Auto layout:
+                <FlaskConicalIcon className="inline" />
+                Experimental
               </strong>{" "}
-              To layout the graph using a layout algorithm use the auto layout
-              menu item. Keyboard shortcut is CTRL+SHIFT+l.
+              Experimental features, they have some rough edges, but can be
+              useful. Use at your own risk.
+              <ul className="ml-6 list-inside list-disc">
+                <li>
+                  <strong>
+                    <LayoutTemplateIcon className="inline" /> Auto layout:
+                  </strong>{" "}
+                  To layout the graph using a layout algorithm use the auto
+                  layout menu item. Keyboard shortcut is CTRL+SHIFT+l.
+                </li>
+                <li>
+                  <strong>
+                    <RouteIcon className="inline" /> Re-route connections:
+                  </strong>{" "}
+                  Re-route connections so they avoid most nodes. Moving nodes
+                  after re-routing will pin the inner bends of the connections.
+                  Keyboard shortcut is CTRL+SHIFT+c.
+                </li>
+                <li>
+                  <strong>
+                    <RouteOffIcon className="inline" />
+                    Undo rerouted connections
+                  </strong>
+                  {""}
+                  Will make whole connection move with nodes again.
+                </li>
+              </ul>
             </li>
           </ul>
         </li>

--- a/src/routes/help.lazy.tsx
+++ b/src/routes/help.lazy.tsx
@@ -286,6 +286,13 @@ function RouteComponent() {
                 </li>
                 <li>
                   <strong>
+                    <LayoutTemplateIcon className="inline" /> Reset auto layout:
+                  </strong>{" "}
+                  To reset the auto layout and move all nodes back to their
+                  naive positions. Any manual changes will be lost.
+                </li>
+                <li>
+                  <strong>
                     <RouteIcon className="inline" /> Re-route connections:
                   </strong>{" "}
                   Re-route connections so they avoid most nodes. Moving nodes
@@ -449,6 +456,13 @@ function RouteComponent() {
                   </strong>{" "}
                   To layout the graph using a layout algorithm use the auto
                   layout menu item. Keyboard shortcut is CTRL+SHIFT+l.
+                </li>
+                <li>
+                  <strong>
+                    <LayoutTemplateIcon className="inline" /> Reset auto layout:
+                  </strong>{" "}
+                  To reset the auto layout and move all nodes back to their
+                  naive positions. Any manual changes will be lost.
                 </li>
                 <li>
                   <strong>

--- a/src/routes/help.lazy.tsx
+++ b/src/routes/help.lazy.tsx
@@ -270,6 +270,7 @@ function RouteComponent() {
               </ul>
             </li>
             <li>
+              <a id="experimental-component" />
               <strong>
                 <FlaskConicalIcon className="inline" />
                 Experimental
@@ -282,7 +283,8 @@ function RouteComponent() {
                     <LayoutTemplateIcon className="inline" /> Auto layout:
                   </strong>{" "}
                   To layout the graph using a layout algorithm use the auto
-                  layout menu item. Keyboard shortcut is CTRL+SHIFT+l.
+                  layout menu item. This will move the component and statement
+                  nodes around. Keyboard shortcut is CTRL+SHIFT+l.
                 </li>
                 <li>
                   <strong>
@@ -295,9 +297,11 @@ function RouteComponent() {
                   <strong>
                     <RouteIcon className="inline" /> Re-route connections:
                   </strong>{" "}
-                  Re-route connections so they avoid most nodes. Moving nodes
-                  after re-routing will pin the inner bends of the connections.
-                  Keyboard shortcut is CTRL+SHIFT+c.
+                  Reroutes connections to avoid overlapping nodes. After
+                  re-routing, moving nodes will not update the connection route;
+                  the inner bends of the connections will stay in same
+                  positions, and only the endpoints will move with the connected
+                  nodes. Keyboard shortcut is CTRL+SHIFT+c.
                 </li>
                 <li>
                   <strong>
@@ -443,6 +447,7 @@ function RouteComponent() {
               </ul>
             </li>
             <li>
+              <a id="experimental-statement" />
               <strong>
                 <FlaskConicalIcon className="inline" />
                 Experimental
@@ -455,7 +460,8 @@ function RouteComponent() {
                     <LayoutTemplateIcon className="inline" /> Auto layout:
                   </strong>{" "}
                   To layout the graph using a layout algorithm use the auto
-                  layout menu item. Keyboard shortcut is CTRL+SHIFT+l.
+                  layout menu item. This will move the component and statement
+                  nodes around. Keyboard shortcut is CTRL+SHIFT+l.
                 </li>
                 <li>
                   <strong>
@@ -468,9 +474,11 @@ function RouteComponent() {
                   <strong>
                     <RouteIcon className="inline" /> Re-route connections:
                   </strong>{" "}
-                  Re-route connections so they avoid most nodes. Moving nodes
-                  after re-routing will pin the inner bends of the connections.
-                  Keyboard shortcut is CTRL+SHIFT+c.
+                  Re-route connections so they avoid most nodes. After
+                  re-routing, moving nodes will not update the connection route;
+                  the inner bends of the connections will stay in same
+                  positions, and only the endpoints will move with the connected
+                  nodes. Keyboard shortcut is CTRL+SHIFT+c.
                 </li>
                 <li>
                   <strong>

--- a/src/routes/network/comp.lazy.tsx
+++ b/src/routes/network/comp.lazy.tsx
@@ -4,12 +4,14 @@ import { ComponentNetwork } from "@/components/ComponentNetwork";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 import { ComponentNetworkMenu } from "@/components/ComponentNetworkMenu";
+import { useLibAvoid } from "@/components/edges";
 
 export const Route = createLazyFileRoute("/network/comp")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
+  useLibAvoid();
   return (
     <ReactFlowProvider>
       <div className="flex h-full flex-col">

--- a/src/routes/network/comp.lazy.tsx
+++ b/src/routes/network/comp.lazy.tsx
@@ -4,14 +4,12 @@ import { ComponentNetwork } from "@/components/ComponentNetwork";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 import { ComponentNetworkMenu } from "@/components/ComponentNetworkMenu";
-import { useLibAvoid } from "@/components/edges";
 
 export const Route = createLazyFileRoute("/network/comp")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  useLibAvoid();
   return (
     <ReactFlowProvider>
       <div className="flex h-full flex-col">

--- a/src/routes/network/statement.lazy.tsx
+++ b/src/routes/network/statement.lazy.tsx
@@ -4,12 +4,14 @@ import { StatementNetwork } from "@/components/StatementNetwork";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 import { StatementNetworkMenu } from "@/components/StatementNetworkMenu";
+import { useLibAvoid } from "@/components/edges";
 
 export const Route = createLazyFileRoute("/network/statement")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
+  useLibAvoid();
   return (
     <ReactFlowProvider>
       <div className="flex h-full flex-col">

--- a/src/routes/network/statement.lazy.tsx
+++ b/src/routes/network/statement.lazy.tsx
@@ -4,14 +4,12 @@ import { StatementNetwork } from "@/components/StatementNetwork";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 import { StatementNetworkMenu } from "@/components/StatementNetworkMenu";
-import { useLibAvoid } from "@/components/edges";
 
 export const Route = createLazyFileRoute("/network/statement")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  useLibAvoid();
   return (
     <ReactFlowProvider>
       <div className="flex h-full flex-col">

--- a/src/stores/component-network.ts
+++ b/src/stores/component-network.ts
@@ -246,3 +246,16 @@ function onConflictsChange(conflicts: Conflict[]) {
 globalStore.subscribe((state) => state.statements, onStatementsChange);
 globalStore.subscribe((state) => state.connections, onConnectionsChange);
 globalStore.subscribe((state) => state.conflicts, onConflictsChange);
+
+export function reset() {
+  const statements = globalStore.getState().statements;
+  const connections = globalStore.getState().connections;
+  const conflicts = globalStore.getState().conflicts;
+  store.setState({
+    nodes: [],
+    edges: [],
+  });
+  onStatementsChange(statements);
+  onConnectionsChange(connections);
+  onConflictsChange(conflicts);
+}

--- a/src/stores/statement-network.ts
+++ b/src/stores/statement-network.ts
@@ -180,3 +180,16 @@ function onConflictsChange(conflicts: Conflict[]) {
 globalStore.subscribe((state) => state.statements, onStatementsChange);
 globalStore.subscribe((state) => state.connections, onConnectionsChange);
 globalStore.subscribe((state) => state.conflicts, onConflictsChange);
+
+export function reset() {
+  const statements = globalStore.getState().statements;
+  const connections = globalStore.getState().connections;
+  const conflicts = globalStore.getState().conflicts;
+  store.setState({
+    nodes: [],
+    edges: [],
+  });
+  onStatementsChange(statements);
+  onConnectionsChange(connections);
+  onConflictsChange(conflicts);
+}


### PR DESCRIPTION
Refs #150

Adds:
- Re-route connections menu item
- Undo rerouted connections menu item
- Reset auto layout menu item

TODO
- [x] fix inline TODOs
- [x] make edge not go across connected nodes
- [x] try out parameters at https://www.adaptagrams.org/documentation/namespaceAvoid.html#a8a0154ae39129e7737d98e5a83daed19a310f9eb2c2d36b367ade5bd9284090c0

Starting point (example loaded + 1 conflict added)
![Example component x1](https://github.com/user-attachments/assets/f44f3e52-cf53-4c57-9ae0-f15734ea1100)
After Re-route connections
![Example component x1 (1)](https://github.com/user-attachments/assets/9abbbfbc-571c-4f91-9b75-72a230b5df07)
After auto layout + re-route (conflicting edge is routed all the way to the west, do not know why)
![Example component x1 (2)](https://github.com/user-attachments/assets/67cd9a96-4a4d-4e66-ad21-69304df8d8ed)
